### PR TITLE
added support for `currentColor` in SVG images

### DIFF
--- a/js/DisclosureMenu.js
+++ b/js/DisclosureMenu.js
@@ -569,7 +569,7 @@ DisclosureMenu.prototype.getMenuCloseSVGNode = function () {
   svg1.appendChild(g1);
 
   let rect1 = document.createElementNS(xmlns, 'rect');
-  rect1.setAttributeNS(null, 'fill', '#13294b');
+  rect1.setAttributeNS(null, 'fill', '#FFFFFF');
   rect1.setAttributeNS(null, 'x', '0');
   rect1.setAttributeNS(null, 'y', '0');
   rect1.setAttributeNS(null, 'width', '32');

--- a/js/DisclosureMenu.js
+++ b/js/DisclosureMenu.js
@@ -1,6 +1,7 @@
 'use strict';
 
 /*
+5
 *   CSS classes and animation names referenced by this script:
 *
 *   menu                      class         WordPress
@@ -90,7 +91,7 @@ function DisclosureMenu (domNode) {
    domNode.setAttribute('role', 'navigation');
   }
   // Add an accessible name to main menu
-  domNode.setAttribute('aria-label', 'Site Menus');
+  domNode.setAttribute('aria-label', 'Site Menu');
 
   this.rootNode = domNode;
 
@@ -140,6 +141,11 @@ function DisclosureMenu (domNode) {
 
   for (i = 0; i < containerNodes.length; i++) {
     containerNode = containerNodes[i];
+    if (containerNode.classList.contains('menu-item-has-children')) {
+      containerNode.querySelector('a').appendChild(this.createMenuToggleSVG());
+    } else {
+      containerNode.querySelector('a').appendChild(this.createMenuLinkSVG());
+    }
 
     // When a menu item gets focus, close any other submenus
     containerNode.addEventListener('focusin', this.handleFocusIn.bind(this));
@@ -159,6 +165,8 @@ function DisclosureMenu (domNode) {
   // Set first and last properties
   this.firstMenuContainer = this.menuContainers[0];
   this.lastMenuContainer = this.menuContainers[this.menuContainers.length - 1];
+
+  this.updateSVGCurrentColorValue();
 
   // Helper functions for constructor
 
@@ -195,6 +203,21 @@ function DisclosureMenu (domNode) {
 }
 
 /* Prototype Methods */
+
+DisclosureMenu.prototype.updateSVGCurrentColorValue = function () {
+  var svgNodes, svgNode, pNode, color;
+
+  svgNodes = document.querySelectorAll('svg');
+  if (svgNodes.length && svgNodes[0].parentNode) {
+    pNode = svgNodes[0].parentNode;
+    color = window.getComputedStyle(pNode).getPropertyValue('color');
+
+    // set the color used by the currentColor value in the SVG
+    for (let i = 0; i < svgNodes.length; i++) {
+      svgNodes[i].setAttribute('color', color);
+    }
+  }
+}
 
 DisclosureMenu.prototype.getMenuContainer = function (node) {
   for (var i = 0; i < this.menuContainers.length; i++) {
@@ -324,6 +347,15 @@ DisclosureMenu.prototype.handleButtonKeydown = function (event) {
     flag = false;
 
   switch (key) {
+    case ' ':
+      var mc = this.getMenuContainer(event.target);
+      if (mc.hasSubMenu) {
+        this.toggleExpand(mc);
+        mc.buttonNode.focus();
+      }
+      flag = true;
+      break;
+
     case 'Esc':
     case 'Escape':
       this.closeMenus();
@@ -537,7 +569,7 @@ DisclosureMenu.prototype.getMenuCloseSVGNode = function () {
   svg1.appendChild(g1);
 
   let rect1 = document.createElementNS(xmlns, 'rect');
-  rect1.setAttributeNS(null, 'fill', '#FFFFFF');
+  rect1.setAttributeNS(null, 'fill', '#13294b');
   rect1.setAttributeNS(null, 'x', '0');
   rect1.setAttributeNS(null, 'y', '0');
   rect1.setAttributeNS(null, 'width', '32');
@@ -553,6 +585,101 @@ DisclosureMenu.prototype.getMenuCloseSVGNode = function () {
   path2.setAttributeNS(null, 'd', 'M8.93264069,6.10421356 L25.9032034,23.0747763 C26.684252,23.8558249 26.684252,25.1221549 25.9032034,25.9032034 C25.1221549,26.684252 23.8558249,26.684252 23.0747763,25.9032034 L6.10421356,8.93264069 C5.32316498,8.1515921 5.32316498,6.88526215 6.10421356,6.10421356 C6.88526215,5.32316498 8.1515921,5.32316498 8.93264069,6.10421356 Z');
   path2.setAttributeNS(null, 'fill', '#13294b');
   g1.appendChild(path2);
+
+  return svg1;
+};
+
+/*
+*   createMenuLinkSVG: Return an SVG image of a chevron pointing rightward.
+*   Its intended use is as a menu button icon that indicates what the
+*   resulting action will be when the button is activated: it serves as a
+*   direct link to another page within the website.
+*/
+DisclosureMenu.prototype.createMenuLinkSVG = function () {
+  const xmlns = 'http://www.w3.org/2000/svg';
+
+  let svg1 = document.createElementNS(xmlns, 'svg');
+  svg1.setAttributeNS(null, 'aria-hidden', 'true');
+  svg1.setAttributeNS(null, 'width', '6px');
+  svg1.setAttributeNS(null, 'height', '11px');
+  svg1.setAttributeNS(null, 'viewBox', '0 0 79 133');
+  svg1.setAttributeNS(null, 'version', '1.1');
+
+  let title1 = document.createElementNS(xmlns, 'title');
+  {
+    let textNode = document.createTextNode('menu link icon');
+    title1.appendChild(textNode);
+  }
+  svg1.appendChild(title1);
+
+  let g1 = document.createElementNS(xmlns, 'g');
+  g1.setAttributeNS(null, 'stroke', 'none');
+  g1.setAttributeNS(null, 'stroke-width', '1');
+  g1.setAttributeNS(null, 'fill', 'none');
+  g1.setAttributeNS(null, 'fill-rule', 'evenodd');
+  svg1.appendChild(g1);
+
+  let g2 = document.createElementNS(xmlns, 'g');
+  g2.setAttributeNS(null, 'transform', 'translate(-293.000000, -69.000000)');
+  g2.setAttributeNS(null, 'fill', 'currentColor');
+  g1.appendChild(g2);
+
+  let g3 = document.createElementNS(xmlns, 'g');
+  g3.setAttributeNS(null, 'transform', 'translate(235.000000, 64.000000)');
+  g2.appendChild(g3);
+
+  let path1 = document.createElementNS(xmlns, 'path');
+  path1.setAttributeNS(null, 'd', 'M33.5,21 C40.4035594,21 46,26.5964406 46,33.5 L46,96.5 L109,96.5 C115.903559,96.5 121.5,102.096441 121.5,109 C121.5,115.903559 115.903559,121.5 109,121.5 L34,121.5 C30.4210403,121.5 27.1933842,119.995891 24.9146718,117.585313 C22.5041093,115.306616 21,112.07896 21,108.5 L21,33.5 C21,26.5964406 26.5964406,21 33.5,21 Z');
+  path1.setAttributeNS(null, 'transform', 'translate(71.250000, 71.250000) rotate(-135.000000) translate(-71.250000, -71.250000) ');
+  g3.appendChild(path1);
+
+  return svg1;
+};
+
+/*
+*   createMenuToggleSVG: Return an SVG image of a chevron pointing downward
+*   that can be rotated 180 degrees to a chevron pointing upward. Its intended
+*   use is as a menu button icon that indicates what the resulting action will
+*   be when the button is activated: it will open the submenu when pointing
+*   downward, or close the submenu when pointing upward.
+*/
+DisclosureMenu.prototype.createMenuToggleSVG = function () {
+  const xmlns = 'http://www.w3.org/2000/svg';
+
+  let svg1 = document.createElementNS(xmlns, 'svg');
+  svg1.setAttributeNS(null, 'aria-hidden', 'true');
+  svg1.setAttributeNS(null, 'width', '11px');
+  svg1.setAttributeNS(null, 'height', '11px');
+  svg1.setAttributeNS(null, 'viewBox', '0 0 133 79');
+  svg1.setAttributeNS(null, 'version', '1.1');
+
+  let title1 = document.createElementNS(xmlns, 'title');
+  {
+    let textNode = document.createTextNode('menu open/close icon');
+    title1.appendChild(textNode);
+  }
+  svg1.appendChild(title1);
+
+  let g1 = document.createElementNS(xmlns, 'g');
+  g1.setAttributeNS(null, 'stroke', 'none');
+  g1.setAttributeNS(null, 'stroke-width', '1');
+  g1.setAttributeNS(null, 'fill', 'none');
+  g1.setAttributeNS(null, 'fill-rule', 'evenodd');
+  svg1.appendChild(g1);
+
+  let g2 = document.createElementNS(xmlns, 'g');
+  g2.setAttributeNS(null, 'transform', 'translate(-50.000000, -122.000000)');
+  g2.setAttributeNS(null, 'fill', 'currentColor');
+  g1.appendChild(g2);
+
+  let g3 = document.createElementNS(xmlns, 'g');
+  g3.setAttributeNS(null, 'transform', 'translate(45.000000, 64.000000)');
+  g2.appendChild(g3);
+
+  let path1 = document.createElementNS(xmlns, 'path');
+  path1.setAttributeNS(null, 'd', 'M33.5,21 C40.4035594,21 46,26.5964406 46,33.5 L46,96.5 L109,96.5 C115.903559,96.5 121.5,102.096441 121.5,109 C121.5,115.903559 115.903559,121.5 109,121.5 L34,121.5 C30.4210403,121.5 27.1933842,119.995891 24.9146718,117.585313 C22.5041093,115.306616 21,112.07896 21,108.5 L21,33.5 C21,26.5964406 26.5964406,21 33.5,21 Z');
+  path1.setAttributeNS(null, 'transform', 'translate(71.250000, 71.250000) rotate(-45.000000) translate(-71.250000, -71.250000) ');
+  g3.appendChild(path1);
 
   return svg1;
 };


### PR DESCRIPTION
The updates to Disclosure menu:
1. Added method `updateSVGCurrentColorValue` (line 207) to add `color` attribute to all SVG graphics in the document using the the parent nodes computed color.
2. Added methods to generating 'Toggle' and 'Link' SVG graphics and they are added during menu creation (e,g, eliminating need for loading  `menuSVG.js` script).